### PR TITLE
Fix the role picking so that it is random, but uniquely distributed.

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -684,7 +684,7 @@ $(function(){
 		// Clear out the role tracking if we inserted all possible roles for the location.
 		if (rolesUsed.length == roles.length){
 			// Pick your poison...
-			//rolesUsed.length = 0;
+			//rolesUsed.length = 0;			
 			rolesUsed.splice(0, rolesUsed.length);
 		}		
 		
@@ -696,6 +696,9 @@ $(function(){
 		do{
 			rolePos = _.random(0, roles.length-1);
 		}while(rolesUsed.includes(rolePos));
+		
+		// Make sure we keep track of the role we're about to return.
+		rolesUsed.push(rolePos);
 		
 		return rolePos;
 	}

--- a/public/index.js
+++ b/public/index.js
@@ -675,14 +675,40 @@ $(function(){
         return roles_numbers;
 
     };
+	
+	function findNextRandomRole(rolesUsed, roles){
+		// So to fix the "random" part giving us the same role over and over again
+		// Track which roles have been given out so far. When we fill every role, clear the list and start over.
+		// This ensures we always have the "most unique" roles we can get.
+
+		// Clear out the role tracking if we inserted all possible roles for the location.
+		if (rolesUsed.length == roles.length){
+			// Pick your poison...
+			//rolesUsed.length = 0;
+			rolesUsed.splice(0, rolesUsed.length);
+		}		
+		
+		var rolePos = -1;
+		
+		// Keep getting a new role position until we get one that isn't in the list.
+		// This may not be the most efficient way to do this, but in our case, optimizing it isn't worth the trouble.
+		// The data sets are tiny, so there's no real reason to make this any faster.
+		do{
+			rolePos = _.random(0, roles.length-1);
+		}while(rolesUsed.includes(rolePos));
+		
+		return rolePos;
+	}
 
     //populate a array with random roles
     // make sure there is always a spy (role 0)
     function getAvailableRoles(playersCount, location){
 
         var originalAllRoles = getLocationRolesAvailable(location);
-        var allRoles = originalAllRoles.slice(0);
-
+		
+		// Used to keep track of which roles have been assigned before we need to assign duplicate roles.
+		// This keeps the randomization as "unique" as possible. People will only get duplicate roles when there are enough players to cause it.
+		var rolesUsed = []; 
         var availableRoles = [];
         for(var i=0;i<playersCount;i++){
             //always have a spy
@@ -692,17 +718,10 @@ $(function(){
             }else if(i===1 && spies===2){
                 availableRoles.push(0);
             //get a random role from the roles available
-            }else{
-                if(allRoles.length===0){
-                    var rolePos = _.random(0,originalAllRoles.length-1);
-                    var role = originalAllRoles[rolePos];
-                    availableRoles.push(role);
-                }else{
-                    var rolePos = _.random(0,allRoles.length-1);
-                    var role = allRoles[rolePos];
-                    allRoles.splice(rolePos,1);
-                    availableRoles.push(role);
-                }
+            }else{				
+				var rolePos = findNextRandomRole(rolesUsed, originalAllRoles);					
+				var role = originalAllRoles[rolePos];
+				availableRoles.push(role);
             }
         }
 


### PR DESCRIPTION
Fixes role picking to be not only "random" but also "unique". Role picking should now ensure that every player has a unique role up until the role list is exhausted, then a second round of random & unique roles are picked.

This fixes the issue where 4+ players would all have the exact same role in a game. (This should now only happen if you really have a lot of players)