### PR TITLE
Added location cross-out functionality

### DIFF
--- a/app/components/Locations/Locations.js
+++ b/app/components/Locations/Locations.js
@@ -1,20 +1,28 @@
 import _ from 'lodash';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { Container, Row, Col } from 'reactstrap';
 import ReactHtmlParser from 'react-html-parser';
-import {css} from 'emotion';
-import {DARK_COLORS, SHADES} from 'styles/consts';
+import { css } from 'emotion';
+import { DARK_COLORS, SHADES } from 'styles/consts';
 import { useTranslation } from 'react-i18next';
 import { DEFAULT_LOCATIONS } from 'consts';
 
-export const Locations = ({location, locations = {}, prevLocation}) => {
+export const Locations = ({ location, locations = {}, prevLocation }) => {
   const [t] = useTranslation();
+  const [sortedLocations, updateSortedLocations] = useState([]);
 
-  const sortedLocations = useMemo(() => {
+  useEffect(() => {
+    updateSortedLocations(initialLocations);
+  }, [initialLocations]);
+
+  const initialLocations = useMemo(() => {
     const locationsArray = _.map(locations, (locationObj, locationId) => ({
       ...locationObj,
-      name: DEFAULT_LOCATIONS[locationId] ? t(`location.${locationId}`) : locationObj.name,
+      name: DEFAULT_LOCATIONS[locationId]
+        ? t(`location.${locationId}`)
+        : locationObj.name,
       locationId,
+      crossOut: false,
     }));
     return _.orderBy(locationsArray, 'name');
   }, [locations, t]);
@@ -29,33 +37,68 @@ export const Locations = ({location, locations = {}, prevLocation}) => {
   const locationsLeft = useMemo(() => locationsChunks[0], [locationsChunks]);
   const locationsRight = useMemo(() => locationsChunks[1], [locationsChunks]);
 
+  const crossOutLocation = (selected) => {
+    const locationsCopy = [...sortedLocations]; // makes copy of locations
+    const index = locationsCopy.indexOf(selected); // gets index of selected location
+    const itemToUpdate = locationsCopy[index]; // selects location to update
+    itemToUpdate.crossOut = !itemToUpdate.crossOut; // sets bool to determine if crossed out
+    updateSortedLocations(locationsCopy); // updates are main sortedLocations array
+  };
+
   return (
     <Container>
       <Row>
         <Col xs={6}>
-          {locationsLeft.map((locationObj) =>
+          {locationsLeft.map((locationObj) => (
             <Row key={locationObj.locationId}>
               <Col>
-                <div className={`${styles.location} ${prevLocation === locationObj.locationId ? styles.prevLocation : ''} ${location === locationObj.locationId ? styles.highlight : ''}`}>
+                <div
+                  onClick={() => crossOutLocation(locationObj)}
+                  className={`${styles.location} 
+                    ${
+                    prevLocation === locationObj.locationId
+                      ? styles.prevLocation
+                      : ''
+                    } ${
+                    locationObj.crossOut && prevLocation !== undefined
+                      ? styles.crossedOut
+                      : ''
+                    } ${
+                    location === locationObj.locationId ? styles.highlight : ''
+                    }`}
+                >
                   {ReactHtmlParser(locationObj.name)}
                 </div>
               </Col>
             </Row>
-          )}
+          ))}
         </Col>
         <Col xs={6}>
-          {locationsRight.map((locationObj) =>
+          {locationsRight.map(locationObj => (
             <Row key={locationObj.locationId}>
               <Col>
-                <div className={`${styles.location} ${prevLocation === locationObj.locationId ? styles.prevLocation : ''} ${location === locationObj.locationId ? styles.highlight : ''}`}>
+                <div
+                  onClick={() => crossOutLocation(locationObj)}
+                  className={`${styles.location} 
+                    ${
+                    prevLocation === locationObj.locationId
+                      ? styles.prevLocation
+                      : ''
+                    } ${
+                    locationObj.crossOut && prevLocation !== undefined
+                      ? styles.crossedOut
+                      : ''
+                    } ${
+                    location === locationObj.locationId ? styles.highlight : ''
+                    }`}
+                >
                   {ReactHtmlParser(locationObj.name)}
                 </div>
               </Col>
             </Row>
-          )}
+          ))}
         </Col>
       </Row>
-
     </Container>
   );
 };
@@ -66,14 +109,20 @@ const styles = {
     textAlign: 'center',
     paddingLeft: 10,
     paddingRight: 10,
+    cursor: 'pointer',
+    userSelect: 'none',
   }),
   prevLocation: css({
+    textDecoration: 'line-through',
+    cursor: 'default',
+  }),
+  crossedOut: css({
     textDecoration: 'line-through',
   }),
   highlight: css({
     fontWeight: 'bold',
-    color: DARK_COLORS.red,
-  }),
+    color: DARK_COLORS.red
+  })
 };
 
 export default Locations;


### PR DESCRIPTION
The user can now cross out locations while playing. This refreshes every game and only applies when the _Locations_ component's prevLocation prop is not _undefined_. 

The config for eslint was a bit messy for my work space so I committed without linting automatically, but did manually fix the majority of the eslint errors. I've attached a screenshot in case there is any worry there. If you would like me to fix it, could you give me some guidelines on how to deal with it best?

![Screenshot from 2020-03-02 15-31-59](https://user-images.githubusercontent.com/27198821/75724250-38bfc680-5c9b-11ea-9d36-14d1868fee5c.png)


Anyways, thank you and let me know if any of my code needs fixing. 

I was playing with some friends the other night, ran into some things, and decided I would like to fix what I can. Great, clean repo :)